### PR TITLE
Specify the plugin `id` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watch": "build-figma-plugin --typecheck --watch"
   },
   "figma-plugin": {
-    "id": "Prototyper",
+    "id": "1020894954864594118",
     "editorType": [
       "figma"
     ],


### PR DESCRIPTION
The plugin ID should be specified under the [**`"id"`**](https://yuanqing.github.io/create-figma-plugin/#id) key of your `package.json`. The `manifest.json` file is generated on-demand, and any changes made to the file will get overridden by the `build-figma-plugin` CLI.